### PR TITLE
Fix date parse function

### DIFF
--- a/TransbankPosSDK/Responses/SaleResponse.cs
+++ b/TransbankPosSDK/Responses/SaleResponse.cs
@@ -58,7 +58,9 @@ namespace Transbank.POS.Responses
             AccountingDate = null;
             if (date != "")
             {
-                AccountingDate = DateTime.ParseExact(date, "ddMMyyyy", DateTimeFormatInfo.InvariantInfo);
+                DateTime parsedDate = new DateTime();
+                DateTime.TryParseExact(date, "ddMMyyyy", DateTimeFormatInfo.InvariantInfo, DateTimeStyles.NoCurrentDateDefault, out parsedDate);
+                AccountingDate = parsedDate;
             }
 
             AccountNumber = fields[ParameterMap["AccountNumber"]].Trim() != "" ? long.Parse(fields[ParameterMap["AccountNumber"]]) : 0;
@@ -70,7 +72,9 @@ namespace Transbank.POS.Responses
             RealDate = null;
             if (date + hour != "")
             {
-                RealDate = DateTime.ParseExact(date + hour, "ddMMyyyyHHmmss", DateTimeFormatInfo.InvariantInfo);
+                DateTime parsedDate = new DateTime();
+                DateTime.TryParseExact(date + hour, "ddMMyyyyHHmmss", DateTimeFormatInfo.InvariantInfo, DateTimeStyles.NoCurrentDateDefault, out parsedDate);
+                RealDate = parsedDate;
             }
 
             EmployeeId = fields[ParameterMap["EmployeeId"]].Trim() != "" ? int.Parse(fields[ParameterMap["EmployeeId"]]) : 0;


### PR DESCRIPTION
The POS sends the blank date with a different format, so had to remove all the dashes (`-`)
Now a invalid date is `1/1/1 12:00:00 AM`