### PR TITLE
Bug/fix read operation problem

### DIFF
--- a/TransbankPosSDK/TransbankPosSDK.csproj
+++ b/TransbankPosSDK/TransbankPosSDK.csproj
@@ -19,7 +19,7 @@
     <VersionPrefix>2.3.1</VersionPrefix>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <Product>TransbankPOSSDK</Product>
-    <Copyright>2020 - Transbank</Copyright>
+    <Copyright>2021 - Transbank</Copyright>
     <RootNamespace>Transbank.POS</RootNamespace>
     <Company>Transbank</Company>
     <Authors>Transbank</Authors>


### PR DESCRIPTION
When the Read ACK method was asynchronous it caused problems with the next read operation.
Now we wait for it to finish before returning the answer. The tests look good.