### PR TITLE
fix: timeout for poll and set normal mode commands

### DIFF
--- a/TransbankPosSDK/POSAutoservicio.cs
+++ b/TransbankPosSDK/POSAutoservicio.cs
@@ -7,6 +7,7 @@ using Transbank.Responses.CommonResponses;
 using Transbank.Responses.AutoservicioResponse;
 using Transbank.Exceptions.AutoservicioExceptions;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace Transbank.POSAutoservicio
 {
@@ -30,15 +31,13 @@ namespace Transbank.POSAutoservicio
 
             try
             {
-                byte[] buffer = new byte[1];
                 string command = "0100";
 
                 Console.WriteLine($"Out (Hex): {ToHexString(command)}");
                 Console.WriteLine($"Out (ASCII): {command}");
 
                 Port.Write(command);
-                await Port.BaseStream.ReadAsync(buffer, 0, 1);
-                return CheckACK(buffer[0]);
+                return await ReadAck(new CancellationTokenSource(ReadTimeout).Token);
             }
             catch (Exception e)
             {

--- a/TransbankPosSDK/POSIntegrado.cs
+++ b/TransbankPosSDK/POSIntegrado.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Transbank.Responses.IntegradoResponses;
 using Transbank.Exceptions.IntegradoExceptions;
 using Transbank.Utils;
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using Transbank.Responses.CommonResponses;
 using Transbank.Exceptions.CommonExceptions;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace Transbank.POSIntegrado
 {
@@ -200,15 +201,13 @@ namespace Transbank.POSIntegrado
             }
             try
             {              
-                byte[] buffer = new byte[1];
                 string command = "0100";
 
                 Console.WriteLine($"Out (Hex): {ToHexString(command)}");
                 Console.WriteLine($"Out (ASCII): {command}");
 
                 Port.Write(command);
-                await Port.BaseStream.ReadAsync(buffer, 0, 1);
-                return CheckACK(buffer[0]);
+                return await ReadAck(new CancellationTokenSource(ReadTimeout).Token);
             }
             catch (Exception e)
             {

--- a/TransbankPosSDK/POSIntegrado.cs
+++ b/TransbankPosSDK/POSIntegrado.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Transbank.Responses.IntegradoResponses;
 using Transbank.Exceptions.IntegradoExceptions;
 using Transbank.Utils;
@@ -226,15 +226,13 @@ namespace Transbank.POSIntegrado
             }
             try
             {
-                byte[] buffer = new byte[1];
                 string command = "0300\0";
 
                 Console.WriteLine($"Out (Hex): {ToHexString(command)}");
                 Console.WriteLine($"Out (ASCII): {command}");
 
                 Port.Write(command);
-                await Port.BaseStream.ReadAsync(buffer, 0, 1);
-                return CheckACK(buffer[0]);
+                return await ReadAck(new CancellationTokenSource(ReadTimeout).Token);
             }
             catch (Exception e)
             {

--- a/TransbankPosSDK/Utils/Serial.cs
+++ b/TransbankPosSDK/Utils/Serial.cs
@@ -1,4 +1,4 @@
-using System.IO.Ports;
+﻿using System.IO.Ports;
 using System.Collections.Generic;
 using System.Text;
 using System;
@@ -111,7 +111,7 @@ namespace Transbank.Utils
             Console.WriteLine($"Out (ASCII): {payload}");
 
             Port.Write(payload);
-            bool ack = ReadAck(new CancellationTokenSource(_timeout).Token);
+            bool ack = ReadAck(new CancellationTokenSource(_timeout).Token).Result;
 
             if (ack)
             {
@@ -221,7 +221,7 @@ namespace Transbank.Utils
             Console.WriteLine($"In (ASCII): {_fullResponse}");
         }
 
-        private bool ReadAck(CancellationToken token)
+        protected async Task<bool> ReadAck(CancellationToken token)
         {
             while (!token.IsCancellationRequested && Port.BytesToRead <= 0)
             {
@@ -231,7 +231,7 @@ namespace Transbank.Utils
                 throw new TransbankException($"Read operation Timeout");
             }
             byte[] result = new byte[1];
-            Port.BaseStream.ReadAsync(result, 0, 1, token).Wait();
+            await Port.BaseStream.ReadAsync(result, 0, 1, token);
             return CheckACK(result[0]);
         }
 

--- a/TransbankPosSDK/Utils/Serial.cs
+++ b/TransbankPosSDK/Utils/Serial.cs
@@ -1,4 +1,4 @@
-﻿using System.IO.Ports;
+using System.IO.Ports;
 using System.Collections.Generic;
 using System.Text;
 using System;
@@ -29,7 +29,7 @@ namespace Transbank.Utils
 
         public List<string> ListPorts() => new List<string>(collection: SerialPort.GetPortNames());
 
-        private int ReadTimeout
+        public int ReadTimeout
         {
             get { return _timeout; }
             set


### PR DESCRIPTION
This PR fix the timeout in Poll and SetNormalMode commands.

## Test

### Timeout in Poll command
<img width="610" alt="image" src="https://github.com/TransbankDevelopers/transbank-pos-sdk-dotnet/assets/36648048/f90bee9e-f427-4b64-a939-a1eaf98bc842">

### Poll Ok
<img width="305" alt="image" src="https://github.com/TransbankDevelopers/transbank-pos-sdk-dotnet/assets/36648048/8cb152a5-6816-4edf-8c0e-ae90b5170fac">

### LoadKeys Ok
<img width="996" alt="image" src="https://github.com/TransbankDevelopers/transbank-pos-sdk-dotnet/assets/36648048/f647d6d4-cd24-4145-8ed7-d8c24486c844">
