### PR TITLE
chore: prepare release 4.0.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,19 @@ Todos los cambios notables a este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 y este proyecto adhiere a [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [4.0.0] - 2024-04-23
+
+### Changed
+- Se cambia el tipo de dato del campo function code de int a string en las respuestas.
+
+### Fix
+- Se arregla un problema que no permitía procesar de forma correcta algunas respuesta del POS.
+- Se arregla un problema que producía que no respondiera el SDK cuando se hacia una operación de Poll o cambio de modo y el POS no se encontrara conectado.
+- Se arregla un problema que provocaba que se cortara el primer caracter del código de función.
+
+### Added
+- Se agrega la posibilidad de asignar el timeout de lectura al puerto.
+
 ## [3.0.2] - 2022-03-01
 
 ### Fix

--- a/TransbankPosSDK/POSAutoservicio.cs
+++ b/TransbankPosSDK/POSAutoservicio.cs
@@ -7,6 +7,7 @@ using Transbank.Responses.CommonResponses;
 using Transbank.Responses.AutoservicioResponse;
 using Transbank.Exceptions.AutoservicioExceptions;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace Transbank.POSAutoservicio
 {
@@ -30,15 +31,13 @@ namespace Transbank.POSAutoservicio
 
             try
             {
-                byte[] buffer = new byte[1];
                 string command = "0100";
 
                 Console.WriteLine($"Out (Hex): {ToHexString(command)}");
                 Console.WriteLine($"Out (ASCII): {command}");
 
                 Port.Write(command);
-                await Port.BaseStream.ReadAsync(buffer, 0, 1);
-                return CheckACK(buffer[0]);
+                return await ReadAck(new CancellationTokenSource(ReadTimeout).Token);
             }
             catch (Exception e)
             {

--- a/TransbankPosSDK/POSAutoservicio.cs
+++ b/TransbankPosSDK/POSAutoservicio.cs
@@ -159,21 +159,6 @@ namespace Transbank.POSAutoservicio
             }
         }
 
-        public async Task<RefundResponse> Refund()
-        {
-            string message = $"1200";
-
-            try
-            {
-                await WriteData(MessageWithLRC(message));
-                return new RefundResponse(CurrentResponse);
-            }
-            catch (Exception e)
-            {
-                throw new TransbankRefundException("Unable to make Refund on POS", e);
-            }
-        }
-
         public async Task<CloseResponse> Close(bool sendVoucher)
         {
             string message = $"0500|{Convert.ToInt32(sendVoucher)}";

--- a/TransbankPosSDK/POSIntegrado.cs
+++ b/TransbankPosSDK/POSIntegrado.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Transbank.Responses.IntegradoResponses;
 using Transbank.Exceptions.IntegradoExceptions;
 using Transbank.Utils;
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using Transbank.Responses.CommonResponses;
 using Transbank.Exceptions.CommonExceptions;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace Transbank.POSIntegrado
 {
@@ -200,15 +201,13 @@ namespace Transbank.POSIntegrado
             }
             try
             {              
-                byte[] buffer = new byte[1];
                 string command = "0100";
 
                 Console.WriteLine($"Out (Hex): {ToHexString(command)}");
                 Console.WriteLine($"Out (ASCII): {command}");
 
                 Port.Write(command);
-                await Port.BaseStream.ReadAsync(buffer, 0, 1);
-                return CheckACK(buffer[0]);
+                return await ReadAck(new CancellationTokenSource(ReadTimeout).Token);
             }
             catch (Exception e)
             {

--- a/TransbankPosSDK/POSIntegrado.cs
+++ b/TransbankPosSDK/POSIntegrado.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Transbank.Responses.IntegradoResponses;
 using Transbank.Exceptions.IntegradoExceptions;
 using Transbank.Utils;
@@ -226,15 +226,13 @@ namespace Transbank.POSIntegrado
             }
             try
             {
-                byte[] buffer = new byte[1];
                 string command = "0300\0";
 
                 Console.WriteLine($"Out (Hex): {ToHexString(command)}");
                 Console.WriteLine($"Out (ASCII): {command}");
 
                 Port.Write(command);
-                await Port.BaseStream.ReadAsync(buffer, 0, 1);
-                return CheckACK(buffer[0]);
+                return await ReadAck(new CancellationTokenSource(ReadTimeout).Token);
             }
             catch (Exception e)
             {

--- a/TransbankPosSDK/Responses/CommonResponses/BasicResponse.cs
+++ b/TransbankPosSDK/Responses/CommonResponses/BasicResponse.cs
@@ -1,4 +1,4 @@
-﻿using Transbank.Utils;
+using Transbank.Utils;
 using System.Collections.Generic;
 
 namespace Transbank.Responses.CommonResponses
@@ -47,7 +47,7 @@ namespace Transbank.Responses.CommonResponses
 
         public BasicResponse(string response)
         {
-            Response = response.Substring(1);
+            Response = response;
         }
 
         public override string ToString()

--- a/TransbankPosSDK/Responses/CommonResponses/BasicResponse.cs
+++ b/TransbankPosSDK/Responses/CommonResponses/BasicResponse.cs
@@ -1,10 +1,13 @@
-using Transbank.Utils;
+﻿using Transbank.Utils;
 using System.Collections.Generic;
 
 namespace Transbank.Responses.CommonResponses
 {
     public class BasicResponse
     {
+        const byte APPROVED_RESPONSE_CODE = 0;
+        const byte INITIALIZATION_OK_RESPONSE_CODE = 90;
+
         private readonly Dictionary<string, int> ParameterMap = new Dictionary<string, int>
         {
             { "FunctionCode", 0},
@@ -42,7 +45,7 @@ namespace Transbank.Responses.CommonResponses
                 return responseCode;
             }
         }
-        public bool Success => ResponseCodes.Map[0].Equals(ResponseMessage) || ResponseCodes.Map[90].Equals(ResponseMessage);
+        public bool Success => ResponseCodes.Map[APPROVED_RESPONSE_CODE].Equals(ResponseMessage) || ResponseCodes.Map[INITIALIZATION_OK_RESPONSE_CODE].Equals(ResponseMessage);
 
         public BasicResponse(string response)
         {

--- a/TransbankPosSDK/Responses/CommonResponses/BasicResponse.cs
+++ b/TransbankPosSDK/Responses/CommonResponses/BasicResponse.cs
@@ -13,12 +13,11 @@ namespace Transbank.Responses.CommonResponses
 
         public string Response { get; }
 
-        public int FunctionCode
+        public string FunctionCode
         {
             get
             {
-                _ = int.TryParse(Response.Split('|')[ParameterMap["FunctionCode"]].Trim(), out int functionCode);
-                return functionCode;
+                return Response.Split('|')[ParameterMap["FunctionCode"]].Trim();
             }
         }
         public string ResponseMessage

--- a/TransbankPosSDK/Responses/CommonResponses/IntermediateResponse.cs
+++ b/TransbankPosSDK/Responses/CommonResponses/IntermediateResponse.cs
@@ -6,7 +6,7 @@ namespace Transbank.Responses.CommonResponses
     {
         private readonly BasicResponse message;
 
-        public int FunctionCode => message.FunctionCode;
+        public string FunctionCode => message.FunctionCode;
         public string ResponseMessage => message.ResponseMessage;
         public int ResponseCode => message.ResponseCode;
 

--- a/TransbankPosSDK/TransbankPosSDK.csproj
+++ b/TransbankPosSDK/TransbankPosSDK.csproj
@@ -42,7 +42,7 @@
   
   <PropertyGroup>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
-    <Version>3.0.3</Version>
+    <Version>4.0.1</Version>
   </PropertyGroup>
     
   <ItemGroup>

--- a/TransbankPosSDK/Utils/Serial.cs
+++ b/TransbankPosSDK/Utils/Serial.cs
@@ -1,4 +1,4 @@
-using System.IO.Ports;
+﻿using System.IO.Ports;
 using System.Collections.Generic;
 using System.Text;
 using System;
@@ -111,7 +111,7 @@ namespace Transbank.Utils
             Console.WriteLine($"Out (ASCII): {payload}");
 
             Port.Write(payload);
-            bool ack = ReadAck(new CancellationTokenSource(_timeout).Token);
+            bool ack = ReadAck(new CancellationTokenSource(_timeout).Token).Result;
 
             if (ack)
             {
@@ -221,7 +221,7 @@ namespace Transbank.Utils
             Console.WriteLine($"In (ASCII): {_fullResponse}");
         }
 
-        private bool ReadAck(CancellationToken token)
+        protected async Task<bool> ReadAck(CancellationToken token)
         {
             while (!token.IsCancellationRequested && Port.BytesToRead <= 0)
             {
@@ -231,7 +231,7 @@ namespace Transbank.Utils
                 throw new TransbankException($"Read operation Timeout");
             }
             byte[] result = new byte[1];
-            Port.BaseStream.ReadAsync(result, 0, 1, token).Wait();
+            await Port.BaseStream.ReadAsync(result, 0, 1, token);
             return CheckACK(result[0]);
         }
 

--- a/TransbankPosSDK/Utils/Serial.cs
+++ b/TransbankPosSDK/Utils/Serial.cs
@@ -1,4 +1,4 @@
-﻿using System.IO.Ports;
+using System.IO.Ports;
 using System.Collections.Generic;
 using System.Text;
 using System;
@@ -29,7 +29,7 @@ namespace Transbank.Utils
 
         public List<string> ListPorts() => new List<string>(collection: SerialPort.GetPortNames());
 
-        private int ReadTimeout
+        public int ReadTimeout
         {
             get { return _timeout; }
             set


### PR DESCRIPTION
Release SDK POS v4.0.0

## Changed
- The data type of the 'function code' field in responses is changed from int to string.

## Fix
- An issue that prevented processing some POS responses correctly has been fixed.
- An issue causing the SDK not to respond when performing a Poll operation or mode change and the POS was not connected has been resolved.
- An issue causing the first character of the function code to be cut off has been fixed.

## Added
- The ability to assign a timeout for reading to the port has been added.