### PR TITLE
feat: improve lrc calculation

### DIFF
--- a/TransbankPosSDK/POSAutoservicio.cs
+++ b/TransbankPosSDK/POSAutoservicio.cs
@@ -13,7 +13,7 @@ namespace Transbank.POSAutoservicio
 {
     public class POSAutoservicio : Serial
     {
-        public POSAutoservicio()
+        public POSAutoservicio() : base(Model.AUTOSERVICIO)
         {
 
         }

--- a/TransbankPosSDK/POSAutoservicio.cs
+++ b/TransbankPosSDK/POSAutoservicio.cs
@@ -105,10 +105,10 @@ namespace Transbank.POSAutoservicio
             {
                 throw new TransbankSaleException("The ticket must be up to 20 characters.");
             }
-            string message = $"0200|{amount}|{ticket}|{Convert.ToInt32(sendVoucher)}|{Convert.ToInt32(sendStatus)}";
+            string message = $"0200|{amount}|{ticket}|{Convert.ToInt32(sendVoucher)}|{Convert.ToInt32(sendStatus)}";
             try
             {
-                await WriteData(MessageWithLRC(message), intermediateMessages: sendStatus);
+                await WriteData(CreateFullMessage(message), intermediateMessages: sendStatus);
                 return new SaleResponse(CurrentResponse);
             }
             catch (Exception e)
@@ -132,10 +132,10 @@ namespace Transbank.POSAutoservicio
                 throw new TransbankMultiCodeSaleException("The ticket must be up to 20 characters.");
             }
             string code = commerceCode != 0 ? commerceCode.ToString() : "";
-            string message = $"0270|{amount}|{ticket}|{Convert.ToInt32(sendVoucher)}|{Convert.ToInt32(sendStatus)}|{code}";
+            string message = $"0270|{amount}|{ticket}|{Convert.ToInt32(sendVoucher)}|{Convert.ToInt32(sendStatus)}|{code}";
             try
             {
-                await WriteData(MessageWithLRC(message), intermediateMessages: sendStatus);
+                await WriteData(CreateFullMessage(message), intermediateMessages: sendStatus);
                 return new MultiCodeSaleResponse(CurrentResponse);
             }
             catch (Exception e)
@@ -148,8 +148,8 @@ namespace Transbank.POSAutoservicio
         {
             try
             {
-                string message = $"0250|{Convert.ToInt32(sendVoucher)}";
-                await WriteData(MessageWithLRC(message));
+                string message = $"0250|{Convert.ToInt32(sendVoucher)}";
+                await WriteData(CreateFullMessage(message));
                 return new LastSaleResponse(CurrentResponse);
             }
             catch (Exception e)
@@ -160,11 +160,11 @@ namespace Transbank.POSAutoservicio
 
         public async Task<CloseResponse> Close(bool sendVoucher)
         {
-            string message = $"0500|{Convert.ToInt32(sendVoucher)}";
+            string message = $"0500|{Convert.ToInt32(sendVoucher)}";
 
             try
-            {          
-                await WriteData(MessageWithLRC(message));
+            {
+                await WriteData(CreateFullMessage(message));
                 return new CloseResponse(CurrentResponse);
             }
             catch (Exception e)

--- a/TransbankPosSDK/POSIntegrado.cs
+++ b/TransbankPosSDK/POSIntegrado.cs
@@ -29,10 +29,10 @@ namespace Transbank.POSIntegrado
             {
                 throw new TransbankSaleException("Amount must be less than 999999999.");
             }
-            string message = $"0200|{amount}|{ticket}|||{Convert.ToInt32(sendStatus)}|";
+            string message = $"0200|{amount}|{ticket}|||{Convert.ToInt32(sendStatus)}|";
             try
             {
-                await WriteData(MessageWithLRC(message), intermediateMessages: sendStatus);
+                await WriteData(CreateFullMessage(message), intermediateMessages: sendStatus);
                 return new SaleResponse(CurrentResponse);
             }
             catch (Exception e)
@@ -56,10 +56,10 @@ namespace Transbank.POSIntegrado
                 throw new TransbankSaleException("Ticket must be 6 characters.");
             }
             string code = commerceCode != 0 ? commerceCode.ToString() : "";
-            string message = $"0270|{amount}|{ticket}|| |{Convert.ToInt32(sendStatus)}|{code}|";
+            string message = $"0270|{amount}|{ticket}|| |{Convert.ToInt32(sendStatus)}|{code}|";
             try
             {
-                await WriteData(MessageWithLRC(message), intermediateMessages: sendStatus);
+                await WriteData(CreateFullMessage(message), intermediateMessages: sendStatus);
                 return new MultiCodeSaleResponse(CurrentResponse);
             }
             catch (Exception e)
@@ -85,8 +85,8 @@ namespace Transbank.POSIntegrado
         {
             try
             {
-                string message = $"0280|{Convert.ToInt32(getVoucherInfo)}";
-                await WriteData(MessageWithLRC(message));
+                string message = $"0280|{Convert.ToInt32(getVoucherInfo)}";
+                await WriteData(CreateFullMessage(message));
                 return new MultiCodeLastSaleResponse(CurrentResponse);
             }
             catch (Exception e)
@@ -98,11 +98,11 @@ namespace Transbank.POSIntegrado
 
         public async Task<RefundResponse> Refund(int operationID)
         {
-            string message = $"1200|{operationID}|";
+            string message = $"1200|{operationID}|";
 
             try
             {
-                await WriteData(MessageWithLRC(message));
+                await WriteData(CreateFullMessage(message));
                 return new RefundResponse(CurrentResponse);
             }
             catch (Exception e)
@@ -126,11 +126,11 @@ namespace Transbank.POSIntegrado
 
         public async Task<List<DetailResponse>> Details(bool printOnPOS = true)
         {
-            string message = $"0260|{Convert.ToInt32(!printOnPOS)}|";
+            string message = $"0260|{Convert.ToInt32(!printOnPOS)}|";
             List<DetailResponse> details = new List<DetailResponse>();
             try
             {
-                await WriteData(MessageWithLRC(message), printOnPOS: printOnPOS, saleDetail: true);
+                await WriteData(CreateFullMessage(message), printOnPOS: printOnPOS, saleDetail: true);
 
                 foreach (string sale in SaleDetail)
                 {
@@ -146,11 +146,11 @@ namespace Transbank.POSIntegrado
 
         public async Task<List<MultiCodeDetailResponse>> MultiCodeDetails(bool printOnPOS = true)
         {
-            string message = $"0260|{Convert.ToInt32(!printOnPOS)}|";
+            string message = $"0260|{Convert.ToInt32(!printOnPOS)}|";
             List<MultiCodeDetailResponse> details = new List<MultiCodeDetailResponse>();
             try
             {
-                await WriteData(MessageWithLRC(message), printOnPOS: printOnPOS, saleDetail: true);
+                await WriteData(CreateFullMessage(message), printOnPOS: printOnPOS, saleDetail: true);
 
                 foreach (string sale in SaleDetail)
                 {

--- a/TransbankPosSDK/Responses/AutoservicioResponse/SaleResponse.cs
+++ b/TransbankPosSDK/Responses/AutoservicioResponse/SaleResponse.cs
@@ -191,7 +191,7 @@ namespace Transbank.Responses.AutoservicioResponse
                 try
                 {
                     string[] arrayResponse = Response.Split('|');
-                    if (arrayResponse.Length <= ParameterMap["PrintingField"])
+                    if (Response.Split('|').Length < 5)
                     {
                         printingField.Add("");
                         return printingField;

--- a/TransbankPosSDK/Responses/AutoservicioResponse/SaleResponse.cs
+++ b/TransbankPosSDK/Responses/AutoservicioResponse/SaleResponse.cs
@@ -191,7 +191,7 @@ namespace Transbank.Responses.AutoservicioResponse
                 try
                 {
                     string[] arrayResponse = Response.Split('|');
-                    if (Response.Split('|').Length < 5)
+                    if (arrayResponse.Length <= ParameterMap["PrintingField"])
                     {
                         printingField.Add("");
                         return printingField;

--- a/TransbankPosSDK/Utils/Serial.cs
+++ b/TransbankPosSDK/Utils/Serial.cs
@@ -21,8 +21,14 @@ namespace Transbank.Utils
         private String _fullResponse;
         protected enum Model
         {
-            INTEGRADO = 0,
-            AUTOSERVICIO = 1,
+            AUTOSERVICIO = 0,
+            INTEGRADO = 1,
+        }
+
+        protected enum LrcStartIndex
+        {
+            AUTOSERVICIO = 0,
+            INTEGRADO = 1,
         }
         protected Model POSType { get; private set; }
         protected string _currentResponse;
@@ -287,10 +293,23 @@ namespace Transbank.Utils
             {
                 return true;
             }
-            int StartIndex = (this.POSType == Model.AUTOSERVICIO) ? 0 : 1;
-            char ReceivedLrc = response[response.Length - 1];
-            char CalculatedLrc = Lrc(response.Substring(0, response.Length - 1), StartIndex);
+            int lrcIndex = response.Length - 1;
+            char ReceivedLrc = response[lrcIndex];
+            var trimmedResponse = response.Substring(0, lrcIndex);
+            char CalculatedLrc = this.POSType == Model.AUTOSERVICIO
+                ? CalculateAutoservicioLrc(trimmedResponse)
+                : CalculateIntegradoLrc(trimmedResponse);
             return ReceivedLrc == CalculatedLrc;
+        }
+
+        protected char CalculateIntegradoLrc(string message)
+        {
+            return Lrc(message, (int)LrcStartIndex.INTEGRADO);
+        }
+
+        protected char CalculateAutoservicioLrc(string message)
+        {
+            return Lrc(message, (int)LrcStartIndex.AUTOSERVICIO);
         }
 
         protected void SendNACK()

--- a/TransbankPosSDK/Utils/Serial.cs
+++ b/TransbankPosSDK/Utils/Serial.cs
@@ -12,6 +12,7 @@ namespace Transbank.Utils
     public class Serial
     {
         protected static readonly byte ACK = 0x06;
+        protected static readonly byte STX = 0x02;
         protected static readonly byte ETX = 0x03;
         protected static readonly int DEFAULT_TIMEOUT = 150000;
         protected static readonly byte NACK = 0x15;
@@ -250,7 +251,7 @@ namespace Transbank.Utils
 
         protected string CreateFullMessage(string message)
         {
-            return "" + message + "" + CalculateLrc(message + "");
+            return $"{(char)STX}{message}{(char)ETX}{CalculateLrc(message + (char)ETX)}";
         }
 
         protected char CalculateLrc(string message)

--- a/TransbankPosSDK/Utils/Serial.cs
+++ b/TransbankPosSDK/Utils/Serial.cs
@@ -256,10 +256,10 @@ namespace Transbank.Utils
             return message + Lrc(message);
         }
 
-        protected char Lrc(string message, int startIndex = 1)
+        protected char CalculateLrc(string message)
         {
             char lrc = (char)0;
-            for (int i = startIndex; i < message.Length; i++)
+            for (int i = 0; i < message.Length; i++)
             {
                 lrc ^= message[i];
             }

--- a/TransbankPosSDK/Utils/Serial.cs
+++ b/TransbankPosSDK/Utils/Serial.cs
@@ -16,16 +16,13 @@ namespace Transbank.Utils
         protected static readonly int DEFAULT_TIMEOUT = 150000;
         protected static readonly byte NACK = 0x15;
         protected static readonly int MAX_NACK_ATTEMPTS = 2;
+        protected static readonly int LRC_LENGTH = 1;
 
         private int _sentNACK;
         private String _fullResponse;
+        private const int AUTOSERVICIO_START_INDEX = 0;
+        private const int INTEGRADO_START_INDEX = 1;
         protected enum Model
-        {
-            AUTOSERVICIO = 0,
-            INTEGRADO = 1,
-        }
-
-        protected enum LrcStartIndex
         {
             AUTOSERVICIO = 0,
             INTEGRADO = 1,
@@ -229,7 +226,7 @@ namespace Transbank.Utils
                     }
                 }
 
-            } while (!CheckLRC(_fullResponse));
+            } while (!CheckReceivedLRC(_fullResponse));
 
             CurrentResponse = _fullResponse.Substring(1, (_fullResponse.Length - 3));
             Port.Write("");
@@ -282,7 +279,7 @@ namespace Transbank.Utils
             return response.Length >= 1 && response.Split('|')[0] == "0900";
         }
 
-        protected bool CheckLRC(String response)
+        protected bool CheckReceivedLRC(String response)
         {
             if (response == String.Empty)
             {
@@ -295,21 +292,16 @@ namespace Transbank.Utils
             }
             int lrcIndex = response.Length - 1;
             char ReceivedLrc = response[lrcIndex];
-            var trimmedResponse = response.Substring(0, lrcIndex);
-            char CalculatedLrc = this.POSType == Model.AUTOSERVICIO
-                ? CalculateAutoservicioLrc(trimmedResponse)
-                : CalculateIntegradoLrc(trimmedResponse);
+            char CalculatedLrc = CalculateResponseLrc(response);
             return ReceivedLrc == CalculatedLrc;
         }
 
-        protected char CalculateIntegradoLrc(string message)
+        private char CalculateResponseLrc(string message)
         {
-            return Lrc(message, (int)LrcStartIndex.INTEGRADO);
-        }
-
-        protected char CalculateAutoservicioLrc(string message)
-        {
-            return Lrc(message, (int)LrcStartIndex.AUTOSERVICIO);
+            int startIndex = POSType == Model.AUTOSERVICIO ? AUTOSERVICIO_START_INDEX : INTEGRADO_START_INDEX;
+            int charsToKeep = message.Length - startIndex - LRC_LENGTH;
+            string trimmedMessage = message.Substring(startIndex, charsToKeep);
+            return CalculateLrc(trimmedMessage);
         }
 
         protected void SendNACK()

--- a/TransbankPosSDK/Utils/Serial.cs
+++ b/TransbankPosSDK/Utils/Serial.cs
@@ -250,10 +250,10 @@ namespace Transbank.Utils
             return message + Lrc(message);
         }
 
-        protected char Lrc(string message)
+        protected char Lrc(string message, int startIndex = 1)
         {
             char lrc = (char)0;
-            for (int i = 1; i < message.Length; i++)
+            for (int i = startIndex; i < message.Length; i++)
             {
                 lrc ^= message[i];
             }
@@ -287,10 +287,10 @@ namespace Transbank.Utils
             {
                 return true;
             }
-
+            int StartIndex = (this.POSType == Model.AUTOSERVICIO) ? 0 : 1;
             char ReceivedLrc = response[response.Length - 1];
-            char CalculatedLrc = Lrc(response.Substring(0, response.Length - 1));
-            return (ReceivedLrc == CalculatedLrc);
+            char CalculatedLrc = Lrc(response.Substring(0, response.Length - 1), StartIndex);
+            return ReceivedLrc == CalculatedLrc;
         }
 
         protected void SendNACK()

--- a/TransbankPosSDK/Utils/Serial.cs
+++ b/TransbankPosSDK/Utils/Serial.cs
@@ -251,9 +251,9 @@ namespace Transbank.Utils
             return CheckACK(result[0]);
         }
 
-        protected string MessageWithLRC(string message)
+        protected string CreateFullMessage(string message)
         {
-            return message + Lrc(message);
+            return "" + message + "" + CalculateLrc(message + "");
         }
 
         protected char CalculateLrc(string message)

--- a/TransbankPosSDK/Utils/Serial.cs
+++ b/TransbankPosSDK/Utils/Serial.cs
@@ -19,7 +19,12 @@ namespace Transbank.Utils
 
         private int _sentNACK;
         private String _fullResponse;
-
+        protected enum Model
+        {
+            INTEGRADO = 0,
+            AUTOSERVICIO = 1,
+        }
+        protected Model POSType { get; private set; }
         protected string _currentResponse;
         protected List<string> SaleDetail;
         private int _timeout;
@@ -50,6 +55,11 @@ namespace Transbank.Utils
                     OnIntermediateMessageReceived(CurrentResponse);
                 }
             }
+        }
+
+        protected Serial(Model posType = Model.INTEGRADO)
+        {
+            POSType = posType;
         }
 
         protected virtual void OnIntermediateMessageReceived(string message)


### PR DESCRIPTION
This PR improves way to calculate LRC on Autoservicio responses.

Load Keys:
<img width="762" height="115" alt="image" src="https://github.com/user-attachments/assets/f4efdabc-d925-4789-89ff-fd801b14410b" />

Poll:
<img width="260" height="67" alt="image" src="https://github.com/user-attachments/assets/af9543cf-1a73-42bb-890f-ff52535a8a62" />

Close:
<img width="307" height="288" alt="image" src="https://github.com/user-attachments/assets/ced7bec3-e2c6-46c9-8f3b-85b08735dd9e" />

Canceled sale:
<img width="384" height="311" alt="image" src="https://github.com/user-attachments/assets/e59f8186-9944-404a-be42-86a6d462107f" />

Ok sale:
<img width="327" height="547" alt="image" src="https://github.com/user-attachments/assets/c4b8ef14-cd27-4d5f-b4d8-7e94e53de0fc" />

Last Sale:
<img width="741" height="338" alt="image" src="https://github.com/user-attachments/assets/fd9ae5e1-88c7-487e-ae88-a84366a7b198" />

Initialization:
<img width="310" height="61" alt="image" src="https://github.com/user-attachments/assets/cd21a5fe-9fa8-42c2-b2ab-b1567ec05ea0" />

Initialization response:
<img width="617" height="103" alt="image" src="https://github.com/user-attachments/assets/d226bef5-1e2e-443a-b8cc-c1a0bfbe1b20" />

