### PR TITLE
feat: improve last sale response

### DIFF
--- a/Transbank.Tests/POSAutoservicioTests.cs
+++ b/Transbank.Tests/POSAutoservicioTests.cs
@@ -128,6 +128,18 @@ namespace Transbank.Tests
         }
 
         [Fact]
+        public async Task PrintLastSaleResponse_ShouldResultOk()
+        {
+            string expected = $"{STX}0260|00|597029414300|IM750015|abc123|414170|12000|6590|62|CR|||VI|28102025|174756{ETX}{(char)0x69}";
+            var task = _pos.LastSale();
+            _mockHandler.SimulateIncoming(expected);
+
+            SaleResponse response = await task;
+
+            Assert.Contains("Function: 0260", response.ToString());
+        }
+
+        [Fact]
         public async Task Close_ShouldReturnValidResponse()
         {
             string expected = $"{STX}0510|00|597029414300|IT750050||{ETX}{(char)0x61}";

--- a/TransbankPosSDK/Responses/AutoservicioResponse/SaleResponse.cs
+++ b/TransbankPosSDK/Responses/AutoservicioResponse/SaleResponse.cs
@@ -191,7 +191,7 @@ namespace Transbank.Responses.AutoservicioResponse
                 try
                 {
                     string[] arrayResponse = Response.Split('|');
-                    if (Response.Split('|').Length < 5)
+                    if (arrayResponse.Length <= ParameterMap["PrintingField"])
                     {
                         printingField.Add("");
                         return printingField;


### PR DESCRIPTION
This PR improves last sale response to avoid exception on to string method.

before:
<img width="1472" height="221" alt="Captura de pantalla 2025-10-29 a las 9 57 43" src="https://github.com/user-attachments/assets/08ceeb8e-ce86-4388-8ced-a5b8585a274f" />

now:
<img width="730" height="305" alt="image" src="https://github.com/user-attachments/assets/5a72266e-0b5e-431b-979e-c97f8657852e" />

tests:
<img width="545" height="129" alt="image" src="https://github.com/user-attachments/assets/1b249aa9-b833-4675-8328-1402b896d964" />
